### PR TITLE
k8s: apps: upgrade registry-1.docker.io/bitnamicharts/keycloak to 24.5.6

### DIFF
--- a/k8s/cluster/apps/keycloak.yml
+++ b/k8s/cluster/apps/keycloak.yml
@@ -21,7 +21,7 @@ spec:
   source:
     repoURL: registry-1.docker.io/bitnamicharts
     chart: keycloak
-    targetRevision: 24.5.7
+    targetRevision: 24.5.6
     helm:
       values: |
         postgresql:


### PR DESCRIPTION
Reverts gastbob40/infrastructure#40